### PR TITLE
Some example updates to get data ingest to work

### DIFF
--- a/src/main/java/org/eclipse/pass/elide/model/Grant.java
+++ b/src/main/java/org/eclipse/pass/elide/model/Grant.java
@@ -15,8 +15,8 @@
  */
 package org.eclipse.pass.elide.model;
 
-import java.time.LocalDateTime;
 import java.util.ArrayList;
+import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -94,17 +94,17 @@ public class Grant {
     /**
      * Date the grant was awarded
      */
-    private LocalDateTime awardDate;
+    private Date awardDate;
 
     /**
      * Date the grant started
      */
-    private LocalDateTime startDate;
+    private Date startDate;
 
     /**
      * Date the grant ended
      */
-    private LocalDateTime endDate;
+    private Date endDate;
 
     /**
      * Status of award/grant

--- a/src/main/java/org/eclipse/pass/elide/model/Policy.java
+++ b/src/main/java/org/eclipse/pass/elide/model/Policy.java
@@ -18,6 +18,7 @@ package org.eclipse.pass.elide.model;
 import java.util.ArrayList;
 import java.util.List;
 
+import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
@@ -46,6 +47,7 @@ public class Policy {
     /**
      * Several sentence description of policy
      */
+    @Column(columnDefinition = "text")
     private String description;
 
     /**

--- a/src/main/java/org/eclipse/pass/elide/model/Policy.java
+++ b/src/main/java/org/eclipse/pass/elide/model/Policy.java
@@ -23,6 +23,7 @@ import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
+import javax.persistence.JoinColumn;
 import javax.persistence.OneToMany;
 
 import com.yahoo.elide.annotation.Include;
@@ -59,6 +60,7 @@ public class Policy {
      * List of URIs for repositories that can satisfying this policy
      */
     @OneToMany
+    @JoinColumn(name = "Repository")
     private List<Repository> repositories = new ArrayList<>();
 
     /**

--- a/src/main/java/org/eclipse/pass/elide/model/Publication.java
+++ b/src/main/java/org/eclipse/pass/elide/model/Publication.java
@@ -15,6 +15,7 @@
  */
 package org.eclipse.pass.elide.model;
 
+import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
@@ -43,6 +44,7 @@ public class Publication {
     /**
      * Abstract of the publication
      */
+    @Column(columnDefinition = "text")
     private String publicationAbstract;
 
     /**

--- a/src/main/java/org/eclipse/pass/elide/model/Repository.java
+++ b/src/main/java/org/eclipse/pass/elide/model/Repository.java
@@ -21,6 +21,7 @@ import java.util.List;
 import java.util.Map;
 
 import javax.persistence.AttributeConverter;
+import javax.persistence.Column;
 import javax.persistence.Convert;
 import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
@@ -63,11 +64,13 @@ public class Repository {
     /**
      * The legal text that a submitter must agree to in order to submit a publication to this repository
      */
+    @Column(columnDefinition = "text")
     private String agreementText;
 
     /**
      * Stringified JSON representing a form template to be loaded by the front-end when this Repository is selected
      */
+    @Column(columnDefinition = "text")
     private String formSchema;
 
     /**

--- a/src/main/java/org/eclipse/pass/elide/model/Submission.java
+++ b/src/main/java/org/eclipse/pass/elide/model/Submission.java
@@ -22,6 +22,7 @@ import java.util.List;
 import java.util.Map;
 
 import javax.persistence.AttributeConverter;
+import javax.persistence.Column;
 import javax.persistence.Convert;
 import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
@@ -48,6 +49,7 @@ public class Submission {
     /**
      * Stringified JSON representation of metadata captured by the relevant repository forms
      */
+    @Column(columnDefinition = "text")
     private String metadata;
 
     /**

--- a/src/main/java/org/eclipse/pass/elide/model/Submission.java
+++ b/src/main/java/org/eclipse/pass/elide/model/Submission.java
@@ -15,8 +15,8 @@
  */
 package org.eclipse.pass.elide.model;
 
-import java.time.LocalDateTime;
 import java.util.ArrayList;
+import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -67,7 +67,7 @@ public class Submission {
     /**
      * Date the record was submitted by the User through PASS
      */
-    private LocalDateTime submittedDate;
+    private Date submittedDate;
 
     /**
      * Status of Submission. Focused on informing User of current state of Submission.


### PR DESCRIPTION
## Example for changing model field mapping of column type:

Some fields need to accommodate long strings, but Elide maps `String` fields to column type varchar(255) by default. Ultimately we need to evaluate the data types for our data model fields, but at a minimum, the fields in this change throw errors with simple example data. This PR is mostly for an example for changing column data types.

Looks like type 'text' is recommended for PostgreSQL anyway (https://www.postgresql.org/docs/current/datatype-character.html)

## Policy OneToMany relationship

`Policy.repositories` has a `@OneToMany` unidirectional relationship with Repository entities. Looks like we need to add a `@JoinColumn(name = "Repository")` to point Elide to the proper Repository table

## Dates

`grant.awardDate`, `grant.startDate`, `grant.endDate` are currently of (Java) type `java.time.LocalDateTime`
Looks like we'd either need a custom converter for this type, or to switch to use `java.util.Date`, which is supported out-of-the-box by Elide.

A custom converter shouldn't be too difficult, whereas moving using `java.util.Date` may require data remediation. I could not get `java.util.Date` to read our timestamps:
|  |  |
| --- | :--- |
| Sample timestamp |  `2017-07-01T00:00:00.000Z` |
| Recognized by `java.util.Date` | `2017-07-01T00:00Z` |